### PR TITLE
Skip over any undefined issues

### DIFF
--- a/lib/repo.js
+++ b/lib/repo.js
@@ -57,6 +57,7 @@ Repo.prototype.spook = function (callback) {
         if (!issues.length) return next();
 
         async.forEachSeries(issues, function (issue, next) {
+            if (!issue) return;
 
             reporterType != 'Base' && template.render('events/test-title', { type: type, url: issue.data.html_url });
 


### PR DESCRIPTION
This causes the error

``` javascript
d:\projects\zobot\node_modules\haunt\lib\repo.js:80
                 suite.addTest(new mocha.Test(key, fn.bind(fn, issue.exports))
                                                                    ^
TypeError: Cannot read property 'exports' of undefined
    at null.<anonymous> (d:\projects\zobot\node_modules\haunt\lib\repo.js:80:76)
    at iterate (d:\projects\zobot\node_modules\haunt\node_modules\async\lib\async.js:108:13)
    at d:\projects\zobot\node_modules\haunt\node_modules\async\lib\async.js:119:25
    at d:\projects\zobot\node_modules\haunt\lib\repo.js:94:17
```
